### PR TITLE
Fix label style

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -49,7 +49,7 @@ class App extends React.Component {
         <VictoryLine
           style={{border: "2px solid black", data: this.state.style}}
           data={this.state.data}
-          label="label"
+          label="label\none"
           animate={{velocity: 0.03}}/>
 
         <VictoryLine style={{border: "2px solid black", data: {stroke: "blue"}}}

--- a/src/components/victory-line.jsx
+++ b/src/components/victory-line.jsx
@@ -179,9 +179,9 @@ class VLine extends React.Component {
     if (!text) {
       return "";
     }
-    const dx = this.style.labels.padding;
     // TODO: split text to new lines based on font size, number of characters and total width
     // TODO: determine line height ("1.2em") based on font size
+    const dx = this.style.labels.padding;
     const textString = "" + text;
     const textLines = textString.split("\n");
     return _.map(textLines, (line, index) => {
@@ -201,8 +201,11 @@ class VLine extends React.Component {
     if (this.props.label) {
       const x = xScale.call(this, _.last(this.dataset).x);
       const y = yScale.call(this, _.last(this.dataset).y);
-      // if label fill color is not given, the label text fill should match
-      // the data stroke color (fill looks much better for text)
+
+      // match labels styles to data style by default (fill, opacity, others?)
+      const opacity = this.style.data.opacity;
+      // match label color to data color if it is not given.
+      // use fill instead of stroke for text
       const fill = this.style.data.stroke;
       return (
         <g>
@@ -210,7 +213,7 @@ class VLine extends React.Component {
           <text
             x={x}
             y={y}
-            style={_.merge({}, this.style.data, {fill}, this.style.labels)}>
+            style={_.merge({}, {fill, opacity}, this.style.labels)}>
             {this.getTextLines(this.props.label, x)}
           </text>
         </g>

--- a/src/components/victory-line.jsx
+++ b/src/components/victory-line.jsx
@@ -21,7 +21,9 @@ const styles = {
     padding: 5,
     fontFamily: "Helvetica",
     fontSize: 10,
-    strokeWidth: 1
+    strokeWidth: 0,
+    stroke: "transparent",
+    textAnchor: "start"
   }
 };
 
@@ -173,6 +175,22 @@ class VLine extends React.Component {
     return props.y;
   }
 
+  getTextLines(text, x) {
+    if (!text) {
+      return "";
+    }
+    const dx = this.style.labels.padding;
+    // TODO: split text to new lines based on font size, number of characters and total width
+    // TODO: determine line height ("1.2em") based on font size
+    const textString = "" + text;
+    const textLines = textString.split("\n");
+    return _.map(textLines, (line, index) => {
+      return index === 0 ?
+      (<tspan x={x} dx={dx} key={"text-line-" + index}>{line}</tspan>) :
+      (<tspan x={x} dx={dx} dy="1.2em" key={"text-line-" + index}>{line}</tspan>);
+    });
+  }
+
   drawLine() {
     const xScale = this.scale.x;
     const yScale = this.scale.y;
@@ -183,15 +201,17 @@ class VLine extends React.Component {
     if (this.props.label) {
       const x = xScale.call(this, _.last(this.dataset).x);
       const y = yScale.call(this, _.last(this.dataset).y);
+      // if label fill color is not given, the label text fill should match
+      // the data stroke color (fill looks much better for text)
+      const fill = this.style.data.stroke;
       return (
         <g>
           <path style={this.style.data} d={lineFunction(this.dataset)}/>
           <text
             x={x}
             y={y}
-            dx={this.style.labels.padding}
-            style={_.merge({}, this.style.data, this.style.labels)}>
-            {this.props.label}
+            style={_.merge({}, this.style.data, {fill}, this.style.labels)}>
+            {this.getTextLines(this.props.label, x)}
           </text>
         </g>
       );


### PR DESCRIPTION
cc/ @exogen 

This PR adds support for multi-line labels for line. It also changes how line labels inherit certain data styles by default. i.e. if label fill / opacity is not provided in the style prop, it will match the stroke / opacity of the data. (using fill for labels instead of stroke as it looks nicer)
