### PR TITLE
filter 0 from default x data, clean up demo

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -5,6 +5,7 @@ import ReactDOM from "react-dom";
 import {VictoryLine} from "../src/index";
 import _ from "lodash";
 import {VictoryLabel} from "victory-label";
+import d3Scale from "d3-scale";
 
 class App extends React.Component {
   constructor(props) {
@@ -48,38 +49,44 @@ class App extends React.Component {
     return (
       <div className="demo">
         <VictoryLine
-          style={{border: "2px solid black", data: this.state.style}}
+          style={{parent: {border: "1px solid black", margin: "5px"}, data: this.state.style}}
           data={this.state.data}
           label={"label\none"}
           animate={{velocity: 0.03}}
         />
 
-        <VictoryLine style={{border: "2px solid black", data: {stroke: "blue"}}}
-          y={(x) => Math.sin(2 * Math.PI * x)}
-          labelComponent={<VictoryLabel>{"label\ntwo"}</VictoryLabel>}
-          sample={25}
-        />
+      <VictoryLine
+        style={{parent: {border: "1px solid black", margin: "5px"}, data: {stroke: "blue"}}}
+        y={(x) => Math.sin(2 * Math.PI * x)}
+        labelComponent={<VictoryLabel>{"label\ntwo"}</VictoryLabel>}
+        sample={25}
+      />
 
-        <VictoryLine style={{border: "2px solid black", data: {stroke: "red"}}}
-          y={(x) => x * x}
-        />
+      <VictoryLine
+        style={{parent: {border: "1px solid black", margin: "5px"}, data: {stroke: "red"}}}
+        y={(x) => x * x}
+      />
 
-        <VictoryLine style={{border: "2px solid black"}}
-          data={[
-            {x: 1, y: 1},
-            {x: 2, y: 3},
-            {x: 3, y: 5},
-            {x: 4, y: 2},
-            {x: 5, y: null},
-            {x: 6, y: null},
-            {x: 7, y: 6},
-            {x: 8, y: 7},
-            {x: 9, y: 8},
-            {x: 10, y: 12}
-          ]}
-        />
+      <VictoryLine
+        style={{parent: {border: "1px solid black", margin: "5px"}}}
+        data={[
+          {x: 1, y: 1},
+          {x: 2, y: 3},
+          {x: 3, y: 5},
+          {x: 4, y: 2},
+          {x: 5, y: null},
+          {x: 6, y: null},
+          {x: 7, y: 6},
+          {x: 8, y: 7},
+          {x: 9, y: 8},
+          {x: 10, y: 12}
+        ]}
+      />
 
-        <VictoryLine style={{border: "2px solid black"}}/>
+      <VictoryLine
+        style={{parent: {border: "1px solid black", margin: "5px"}}}
+        scale={{x: d3Scale.linear(), y: d3Scale.log()}}
+      />
       </div>
     );
   }

--- a/src/components/victory-line.jsx
+++ b/src/components/victory-line.jsx
@@ -271,7 +271,8 @@ export default class VictoryLine extends React.Component {
     const step = _.max(domain) / samples;
     // return an array of x values spaced across the domain,
     // include the maximum of the domain
-    return _.union(_.range(_.min(domain), _.max(domain), step), [_.max(domain)]);
+    const xArray = _.union(_.range(_.min(domain), _.max(domain), step), [_.max(domain)]);
+    return _.filter(xArray, (x) => x !== 0);
   }
 
   returnOrGenerateY(props, x) {


### PR DESCRIPTION
cc/ @coopy or @kenwheeler 
@kenwheeler reported an issue where plotting a log scale chart with no data resulted in an invalid path. This was caused by the default data having zero values, which result in `-Infinity` when plotted on a log scale. This PR filters 0 from the default x data array so that the default data wont cause log scales to break. Data passed via props is not filtered. 

I would really like to be able to introspect on the type of scale currently in use. Related issue / feature request https://github.com/d3/d3-scale/issues/25
